### PR TITLE
Can't set CORS headers for eventsource responses

### DIFF
--- a/example/bar/bar.rb
+++ b/example/bar/bar.rb
@@ -13,6 +13,9 @@ class Bar < Angelo::Base
   include Angelo::Mustermann unless RUBY_PLATFORM == 'java'
 
   HEART = '❤️'
+  CORS = { 'Access-Control-Allow-Origin' => '*',
+           'Access-Control-Allow-Methods' => 'GET, POST',
+           'Access-Control-Allow-Headers' => 'Accept, Authorization, Content-Type, Origin' }
   @@ping_time = 3
   @@hearting = false
   @@beating = false
@@ -149,17 +152,18 @@ class Bar < Angelo::Base
   end
 
   options '/cors' do
-    headers 'Access-Control-Allow-Origin' => '*',
-            'Access-Control-Allow-Methods' => 'GET, POST',
-            'Access-Control-Allow-Headers' => 'Accept, Authorization, Content-Type, Origin'
+    headers CORS
     nil
   end
 
   get '/cors' do
-    headers 'Access-Control-Allow-Origin' => '*',
-            'Access-Control-Allow-Methods' => 'GET, POST',
-            'Access-Control-Allow-Headers' => 'Accept, Authorization, Content-Type, Origin'
+    headers CORS
     'hi there'
+  end
+
+  eventsource '/sse_cors', CORS do |c|
+    c.write sse_event :cors, 'cors!'
+    c.close
   end
 
 end

--- a/lib/angelo/base.rb
+++ b/lib/angelo/base.rb
@@ -93,8 +93,8 @@ module Angelo
         routes[:websocket][path] = Responder::Websocket.new &block
       end
 
-      def eventsource path, &block
-        routes[:get][path] = Responder::Eventsource.new &block
+      def eventsource path, headers = nil, &block
+        routes[:get][path] = Responder::Eventsource.new headers, &block
       end
 
       def on_pong &block

--- a/lib/angelo/mustermann.rb
+++ b/lib/angelo/mustermann.rb
@@ -33,9 +33,9 @@ module Angelo
         super path, &block
       end
 
-      def eventsource path, &block
+      def eventsource path, headers = nil, &block
         path = ::Mustermann.new path
-        super path, &block
+        super path, headers, &block
       end
 
       def routes

--- a/lib/angelo/responder/eventsource.rb
+++ b/lib/angelo/responder/eventsource.rb
@@ -2,6 +2,11 @@ module Angelo
   class Responder
     class Eventsource < Responder
 
+      def initialize _headers = nil, &block
+        headers _headers if _headers
+        super &block
+      end
+
       def request= request
         @params = nil
         @request = request

--- a/test/angelo/eventsource_spec.rb
+++ b/test/angelo/eventsource_spec.rb
@@ -16,6 +16,11 @@ describe Angelo::Responder::Eventsource do
         c.close
       end
 
+      eventsource '/headers', foo: 'bar' do |c|
+        c.write sse_event :sse, 'headers'
+        c.close
+      end
+
     end
 
     it 'sends messages' do
@@ -28,6 +33,13 @@ describe Angelo::Responder::Eventsource do
       get_sse '/event' do |msg|
         msg.must_equal "event: sse\ndata: bye\n\n"
       end
+    end
+
+    it 'accepts extra headers hash as second optional parameter' do
+      get_sse '/headers' do |msg|
+        msg.must_equal "event: sse\ndata: headers\n\n"
+      end
+      last_response.headers['Foo'].must_equal 'bar'
     end
 
   end
@@ -52,10 +64,10 @@ describe 'eventsource helper' do
       end
     end
 
-    get '/headers_out' do
+    get '/headers' do
       headers foo: 'bar'
       eventsource do |c|
-        c.write sse_event :sse, 'headers_out'
+        c.write sse_event :sse, 'headers'
         c.close
       end
     end
@@ -75,10 +87,10 @@ describe 'eventsource helper' do
   end
 
   it 'allows headers to be set outside block' do
-    get_sse '/headers_out' do |msg|
-      msg.must_equal "event: sse\ndata: headers_out\n\n"
+    get_sse '/headers' do |msg|
+      msg.must_equal "event: sse\ndata: headers\n\n"
     end
-    last_response.headers['foo'].must_equal 'bar'
+    last_response.headers['Foo'].must_equal 'bar'
   end
 
 end


### PR DESCRIPTION
Setting headers in the eventsource block is ineffective because the headers have already been sent using the SSE_HEADER constant. I have to had redefine this constant to get it to work. Maybe the eventsource method could accept a hash of headers that you could merge with SSE_HEADER.
