### PR TITLE
DELETE and OPTIONS requests should see query string params

### DIFF
--- a/lib/angelo/base.rb
+++ b/lib/angelo/base.rb
@@ -166,9 +166,10 @@ module Angelo
 
     def params
       @params ||= case request.method
-                  when GET;  parse_query_string
-                  when POST; parse_post_body
-                  when PUT;  parse_post_body
+                  when GET, DELETE, OPTIONS
+                    parse_query_string
+                  when POST, PUT
+                    parse_post_body
                   end
     end
 

--- a/test/angelo/websocket_spec.rb
+++ b/test/angelo/websocket_spec.rb
@@ -194,7 +194,7 @@ describe Angelo::Responder::Websocket do
       Angelo::HTTPABLE.each do |m|
         __send__ m, '/concur' do
           websockets.each do |ws|
-            msg = "from #{params ? params[:foo] : 'http'} #{m.to_s}"
+            msg = "from #{params[:foo]} #{m.to_s}"
             ws.write msg
           end
           ''
@@ -216,7 +216,7 @@ describe Angelo::Responder::Websocket do
       }
 
       websocket_wait_for '/concur', latch, expectation do
-        Angelo::HTTPABLE.each {|m| __send__ m, '/concur', foo: 'http'}
+        Angelo::HTTPABLE.each {|m| __send__ m, '/concur?foo=http'}
         latch.wait
       end
 

--- a/test/angelo_spec.rb
+++ b/test/angelo_spec.rb
@@ -385,7 +385,7 @@ describe Angelo::Base do
 
     define_app do
 
-      [:get, :post].each do |m|
+      Angelo::HTTPABLE.each do |m|
         __send__ m, '/json' do
           content_type :json
           params
@@ -407,6 +407,13 @@ describe Angelo::Base do
     it 'does not parse body when request content-type not set' do
       post '/json', obj, {'Content-Type' => ''}
       last_response_must_be_json({})
+    end
+
+    (Angelo::HTTPABLE - [:post, :put]).each do |m|
+      it "returns a populated hash for #{m.to_s.upcase} requests" do
+        send m, '/json?foo=bar'
+        last_response_must_be_json('foo' => 'bar')
+      end
     end
 
   end


### PR DESCRIPTION
The tests have to pass the params as a string rather than a hash
because httpclient has a similar bug.

https://github.com/nahi/httpclient/issues/136
