### PR TITLE
Fix removal of dead sockets from the stash

### DIFF
--- a/lib/angelo/stash.rb
+++ b/lib/angelo/stash.rb
@@ -38,7 +38,6 @@ module Angelo
     #
     def << s
       peeraddrs[s] = s.peeraddr
-      yield if block_given?
       stashes[@context] << s
     end
 
@@ -118,9 +117,8 @@ module Angelo
       include Stash
 
       def << ws
-        super do
-          @server.async.handle_websocket ws
-        end
+        super
+        @server.async.handle_websocket ws
       end
 
     end

--- a/test/angelo/stash_spec.rb
+++ b/test/angelo/stash_spec.rb
@@ -1,0 +1,49 @@
+require_relative '../spec_helper'
+
+describe Angelo::Stash do
+
+  describe 'error handling' do
+
+    class ErrorSocket
+
+      def read *args
+        raise IOError
+      end
+
+      def closed?
+        true
+      end
+
+    end
+
+    class TestStash
+      extend Angelo::Stash::ClassMethods
+      include Angelo::Stash
+
+      def << s
+        peeraddrs[s] = [nil, 'hi from tests']
+        stashes[@context] << s
+      end
+
+    end
+
+    it 'does not skip live sockets when removing dead sockets' do
+      err_sock = ErrorSocket.new
+
+      good_sock = Minitest::Mock.new
+      good_sock.expect :read, "hi"
+      good_sock.expect :hash, 123
+      def good_sock.== o; o == self; end
+
+      stash = TestStash.new nil
+
+      stash << err_sock
+      stash << good_sock
+
+      stash.each {|s| s.read}
+      good_sock.verify
+    end
+
+  end
+
+end


### PR DESCRIPTION
We were modifying the stash array while iterating over it, causing sockets that were still connected to miss messages.

This was a bit of a head scratcher! I thought about using `reject!` but that would have meant calling `remove_socket` in such a way that it wouldn't actually do the removal. No test case because this seems like a tricky one to test. I'm short on time and you could probably do it much quicker.
