### PR TITLE
on_close proof of concept

### DIFF
--- a/lib/angelo/responder.rb
+++ b/lib/angelo/responder.rb
@@ -30,7 +30,7 @@ module Angelo
 
     end
 
-    attr_accessor :connection
+    attr_accessor :connection, :on_close
     attr_reader :request
     attr_writer :base
 


### PR DESCRIPTION
I felt a little bad that you'd gone and done all that work as I wasn't entirely sure whether I needed this yet. I was merely asking to see whether it was even worth considering. It would be a useful feature to have in any case but I really hate polling so I spent a little more time to see whether I could improve on that. I knew from prior experience that the server generally knows when the client has explicitly disconnected but I needed to determine exactly where it was waiting for that to happen. I tracked it down to the `connection.each_request` line. I then hacked up a way to pass through a call back from the application. It would look something like this.

``` ruby
eventsource "/sse" do
  # Send some stuff and leave connection open.
  responder.on_close = proc do
    logger.fatal "Client has gone away!"
  end
end
```

You may want to improve on the syntax a bit but this at least shows that it works.
