### PR TITLE
Optparse

### DIFF
--- a/lib/angelo/base.rb
+++ b/lib/angelo/base.rb
@@ -30,6 +30,10 @@ module Angelo
         subclass.ping_time DEFAULT_PING_TIME
         subclass.log_level DEFAULT_LOG_LEVEL
 
+        # Parse options if angelo/main was required.
+        #
+        subclass.parse_options if subclass.respond_to? :parse_options
+
         class << subclass
 
           def root

--- a/lib/angelo/main.rb
+++ b/lib/angelo/main.rb
@@ -1,0 +1,29 @@
+require "angelo"
+
+module Angelo
+  class Base
+    def self.parse_options
+      require "optparse"
+
+      optparse = OptionParser.new do |op|
+        op.banner = "Usage: #{$0} [options]"
+
+        op.on('-p port', OptionParser::DecimalInteger, "set the port (default is #{port})") {|val| port val}
+        op.on('-o addr', "set the host (default is #{addr})") {|val| addr val}
+
+        op.on('-h', '--help', "Show this help") do
+          puts op
+          exit
+        end
+      end
+
+      begin
+        optparse.parse(ARGV)
+      rescue OptionParser::ParseError => ex
+        $stderr.puts ex
+        $stderr.puts optparse
+        exit 1
+      end
+    end
+  end
+end

--- a/test/angelo/main_spec.rb
+++ b/test/angelo/main_spec.rb
@@ -2,8 +2,8 @@ require_relative '../spec_helper'
 require 'angelo/main'
 
 describe "angelo/main" do
-  describe "parses" do
-    def with_args(args, &block)
+  helpers = Module.new do
+    def self.with_args(args, &block)
       orig_argv = ARGV.dup
       begin
         ARGV.replace(args.split)
@@ -12,19 +12,37 @@ describe "angelo/main" do
         ARGV.replace(orig_argv)
       end
     end
+  end
 
+  describe "parses" do
     it "-p port" do
-      with_args("-p 12345") do
+      helpers.with_args("-p 12345") do
         klass = Class.new(Angelo::Base)
         klass.port.must_equal 12345
       end
     end
 
     it "-o addr" do
-      with_args("-o 3.2.1.0") do
+      helpers.with_args("-o 3.2.1.0") do
         klass = Class.new(Angelo::Base)
         klass.addr.must_equal "3.2.1.0"
       end
+    end
+  end
+
+  it "uses defaults if not specified" do
+    helpers.with_args("") do
+      klass = Class.new(Angelo::Base)
+      klass.port.must_equal Angelo::DEFAULT_PORT
+      klass.addr.must_equal Angelo::DEFAULT_ADDR
+    end
+  end
+
+  it "doesn't alter ARGV" do
+    helpers.with_args("-p 1234 -o 109.87.65.43") do
+      pre_args = ARGV.dup
+      Class.new(Angelo::Base)
+      ARGV.must_equal pre_args
     end
   end
 end

--- a/test/angelo/main_spec.rb
+++ b/test/angelo/main_spec.rb
@@ -5,8 +5,8 @@ describe "angelo/main" do
   helpers = Module.new do
     def self.with_args(args, &block)
       orig_argv = ARGV.dup
+      ARGV.replace(args.split)
       begin
-        ARGV.replace(args.split)
         block.call
       ensure
         ARGV.replace(orig_argv)

--- a/test/angelo/main_spec.rb
+++ b/test/angelo/main_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../spec_helper'
+require 'angelo/main'
+
+describe "angelo/main" do
+  describe "parses" do
+    def with_args(args, &block)
+      orig_argv = ARGV.dup
+      begin
+        ARGV.replace(args.split)
+        block.call
+      ensure
+        ARGV.replace(orig_argv)
+      end
+    end
+
+    it "-p port" do
+      with_args("-p 12345") do
+        klass = Class.new(Angelo::Base)
+        klass.port.must_equal 12345
+      end
+    end
+
+    it "-o addr" do
+      with_args("-o 3.2.1.0") do
+        klass = Class.new(Angelo::Base)
+        klass.addr.must_equal "3.2.1.0"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds parsing of -p port and -o addr if "angelo/main" is required.

It works, and has tests, and it would be ok to merge, but IMO it's not quite the direction to go in.  What I'd really like to see is the sinatra model where require "angelo" pulls in the whole ball of wax including "angelo/main" which arranges to parse the args and runs via at_exit if it should, and require "angelo/base" just gets you what require "angelo" gets now.  Just a simple bit of refactoring.