### PR TITLE
Optparse2

### DIFF
--- a/lib/angelo/base.rb
+++ b/lib/angelo/base.rb
@@ -30,6 +30,10 @@ module Angelo
         subclass.ping_time DEFAULT_PING_TIME
         subclass.log_level DEFAULT_LOG_LEVEL
 
+        # Parse options if angelo/main was required.
+        #
+        subclass.parse_options(ARGV.dup) if subclass.respond_to? :parse_options
+
         class << subclass
 
           def root

--- a/lib/angelo/main.rb
+++ b/lib/angelo/main.rb
@@ -1,0 +1,29 @@
+require "angelo"
+
+module Angelo
+  class Base
+    def self.parse_options(argv)
+      require "optparse"
+
+      optparse = OptionParser.new do |op|
+        op.banner = "Usage: #{$0} [options]"
+
+        op.on('-p port', OptionParser::DecimalInteger, "set the port (default is #{port})") {|val| port val}
+        op.on('-o addr', "set the host (default is #{addr})") {|val| addr val}
+
+        op.on('-h', '--help', "Show this help") do
+          puts op
+          exit
+        end
+      end
+
+      begin
+        optparse.parse(argv)
+      rescue OptionParser::ParseError => ex
+        $stderr.puts ex
+        $stderr.puts optparse
+        exit 1
+      end
+    end
+  end
+end

--- a/test/angelo/main_spec.rb
+++ b/test/angelo/main_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../spec_helper'
+require 'angelo/main'
+
+describe Angelo::Base do
+  describe "parses" do
+    it "-p port" do
+      Class.new(Angelo::Base).instance_eval do
+        parse_options("-p 12345".split)
+        port.must_equal 12345
+      end
+    end
+
+    it "-o addr" do
+      Class.new(Angelo::Base).instance_eval do
+        parse_options("-o 3.2.1.0".split)
+        addr.must_equal "3.2.1.0"
+      end
+    end
+  end
+end

--- a/test/angelo/main_spec.rb
+++ b/test/angelo/main_spec.rb
@@ -4,14 +4,14 @@ require 'angelo/main'
 describe Angelo::Base do
   describe "parses" do
     it "-p port" do
-      Class.new(Angelo::Base).instance_eval do
+      Class.new(Angelo::Base) do
         parse_options("-p 12345".split)
         port.must_equal 12345
       end
     end
 
     it "-o addr" do
-      Class.new(Angelo::Base).instance_eval do
+      Class.new(Angelo::Base) do
         parse_options("-o 3.2.1.0".split)
         addr.must_equal "3.2.1.0"
       end


### PR DESCRIPTION
Here's an alternative pull request.  Angelo::Base parse_options is called with ARGV.dup instead of accessing ARGV directly.  The old tests still work with this simple refactor.  But here the tests have been modified to call parse_options directly, so it's more of a unit test,  and no longer tests that parse_options is called with ARGV when subclassing Angelo::Base if angelo/main has been required.  I'm never quite sure how to test things.  I'm not sure anybody really is.  But if you've got any thoughts, let me know.