### PR TITLE
Remove constant ROUTABLE and simplify code that used it.

### DIFF
--- a/lib/angelo.rb
+++ b/lib/angelo.rb
@@ -14,7 +14,6 @@ module Angelo
   DELETE =  'DELETE'
   OPTIONS = 'OPTIONS'
 
-  ROUTABLE = [:get, :post, :put, :delete, :options, :websocket]
   HTTPABLE = [:get, :post, :put, :delete, :options]
   STATICABLE = [:get, :head]
 

--- a/lib/angelo/base.rb
+++ b/lib/angelo/base.rb
@@ -88,11 +88,7 @@ module Angelo
       end
 
       def routes
-        @routes ||= {}
-        ROUTABLE.each do |m|
-          @routes[m] ||= {}
-        end
-        @routes
+        @routes ||= Hash.new{|h,k| h[k] = {}}
       end
 
       def filters

--- a/lib/angelo/mustermann.rb
+++ b/lib/angelo/mustermann.rb
@@ -39,11 +39,7 @@ module Angelo
       end
 
       def routes
-        @routes ||= {}
-        ROUTABLE.each do |m|
-          @routes[m] ||= RouteMap.new
-        end
-        @routes
+        @routes ||= Hash.new{|h,k| h[k] = RouteMap.new}
       end
 
       def filter_by which, path, meth


### PR DESCRIPTION
Here's an easy one.  There doesn't seem to be any reason for ROUTABLE other than to initialize a few hashes that are better off using an init block UNLESS you want routes[<non-routable>] to return nil so the downstream code fails but I don't think that's the case.