### PR TITLE
Add test coverage with SimpleCov on MRI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 angelo-*.gem
 tmp
 Gemfile.lock
+test/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,8 @@ end
 group :test do
   gem 'httpclient', '~>2.5'
   gem 'minitest', '~>5.4'
+
+  platform :mri do
+    gem 'simplecov', '~>0.9.1'
+  end
 end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,5 +1,12 @@
 $:.unshift File.expand_path '../../lib', __FILE__
 
+if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION >= "1.9"
+  require 'simplecov'
+  SimpleCov.coverage_dir File.join('test', 'coverage')
+  SimpleCov.start
+  SimpleCov.command_name 'minitest'
+end
+
 require 'bundler'
 Bundler.require :default, :development, :test
 require 'minitest/pride'


### PR DESCRIPTION
This adds SimpleCov testing. When the tests are run on MRI (does not run on RBX or JRuby), it will generate a `test/coverage` directory which is ignored in `.gitignore`, and gives a good way to check for missing tests and missed conditionals and stuff like that. Just point your browser to `angelo/test/coverage/index.html` to see locally. I have uploaded the tests to my Neocities account so you can inspect the current output: http://kyledrake.neocities.org/angelo-coverage/index.html

It would not be much more work to integrate [Coveralls](https://coveralls.io), giving you a nice button to put on the README, just like we did with [BitcoinJS](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/README.md).

Super useful for improving testing, never hurts to have another vector there.