### PR TITLE
Symhash2

### DIFF
--- a/lib/angelo/params_parser.rb
+++ b/lib/angelo/params_parser.rb
@@ -1,4 +1,5 @@
 require 'cgi'
+require_relative 'symhash'
 
 module Angelo
 
@@ -9,7 +10,7 @@ module Angelo
     EMPTY_JSON = '{}'
 
     def parse_formencoded str
-      str.split(AMPERSAND).reduce(Responder.symhash) do |p, kv|
+      str.split(AMPERSAND).reduce(SymHash.new) do |p, kv|
         key, value = kv.split(EQUALS).map {|s| CGI.unescape s}
         p[key] = value
         p
@@ -39,7 +40,7 @@ module Angelo
     def recurse_symhash h
       h.each do |k,v|
         if Hash === v
-          h[k] = Responder.symhash.merge! v
+          h[k] = SymHash.new.merge! v
           recurse_symhash h[k]
         end
       end

--- a/lib/angelo/params_parser.rb
+++ b/lib/angelo/params_parser.rb
@@ -30,21 +30,10 @@ module Angelo
         qs.merge! body
       when json?
         body = EMPTY_JSON if body.empty?
-        body = JSON.parse body
-        recurse_symhash qs.merge! body
+        qs.merge! JSON.parse body
       else
         qs
       end
-    end
-
-    def recurse_symhash h
-      h.each do |k,v|
-        if Hash === v
-          h[k] = SymHash.new.merge! v
-          recurse_symhash h[k]
-        end
-      end
-      h
     end
 
     def form_encoded?

--- a/lib/angelo/responder.rb
+++ b/lib/angelo/responder.rb
@@ -25,10 +25,6 @@ module Angelo
         @default_headers
       end
 
-      def symhash
-        Hash.new {|hash,key| hash[key.to_s] if Symbol === key }
-      end
-
     end
 
     attr_accessor :connection, :request

--- a/lib/angelo/symhash.rb
+++ b/lib/angelo/symhash.rb
@@ -8,7 +8,7 @@ module Angelo
 
     def merge!(other)
       super.tap do |result|
-        result.each do |k,v|
+        other.each do |k,v|
           # If any of the merged values are Hashes, replace them with
           # SymHashes all the way down.
           if v.kind_of?(Hash)

--- a/lib/angelo/symhash.rb
+++ b/lib/angelo/symhash.rb
@@ -1,0 +1,9 @@
+module Angelo
+  class SymHash < Hash
+    # Returns a Hash that allows values to be fetched with String or
+    # Symbol keys.
+    def initialize
+      super {|hash,key| hash[key.to_s] if Symbol === key}
+    end
+  end
+end

--- a/lib/angelo/symhash.rb
+++ b/lib/angelo/symhash.rb
@@ -5,5 +5,18 @@ module Angelo
     def initialize
       super {|hash,key| hash[key.to_s] if Symbol === key}
     end
+
+    def merge!(other)
+      super.tap do |result|
+        result.each do |k,v|
+          # If any of the merged values are Hashes, replace them with
+          # SymHashes all the way down.
+          if v.kind_of?(Hash)
+            result[k] = self.class.new.merge!(v)
+          end
+        end
+      end
+    end
+
   end
 end

--- a/test/angelo/symhash_spec.rb
+++ b/test/angelo/symhash_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../spec_helper'
+require "angelo/symhash"
+
+describe Angelo::SymHash do
+  describe ".new" do
+    it "returns a Hash" do
+      Angelo::SymHash.new.must_be_kind_of Hash
+    end
+  end
+
+  it "fetches values for Symbols that were inserted with Strings" do
+    symhash = Angelo::SymHash.new
+    symhash["x"] = "y"
+    symhash["x"].must_equal "y"
+    symhash[:x].must_equal "y"
+  end
+end

--- a/test/angelo/symhash_spec.rb
+++ b/test/angelo/symhash_spec.rb
@@ -14,4 +14,30 @@ describe Angelo::SymHash do
     symhash["x"].must_equal "y"
     symhash[:x].must_equal "y"
   end
+
+  describe "#merge!" do
+    it "returns self" do
+      symhash = Angelo::SymHash.new
+      result = symhash.merge!("one" => "two")
+      result.must_be_same_as symhash
+    end
+
+    it "recursively merges a Hash into self" do
+      hash = {
+        "foo" => {
+          "bar" => "baz",
+          "that" => {
+            "holmes" => true,
+          },
+        },
+      }
+
+      symhash = Angelo::SymHash.new.merge!(hash)
+      symhash["foo"]["bar"].must_equal "baz"
+      symhash[:foo][:bar].must_equal "baz"
+      symhash["foo"]["that"]["holmes"].must_equal true
+      symhash[:foo][:that][:holmes].must_equal true
+    end
+  end
+
 end


### PR DESCRIPTION
Having a Responder.symhash method was confusing. This makes a new SymHash class with a merge! method for folding a Hash into it.  It's easier to understand if you look at the four commits individually.

I've got some more changes in mind to make the query and body parsing a little easier to follow, but this needed to be done first.
