### PR TITLE
minitest helper addition for testing angelo::base subclasses

### DIFF
--- a/test/angelo_spec.rb
+++ b/test/angelo_spec.rb
@@ -442,6 +442,20 @@ describe Angelo::Base do
 
   end
 
+  class MyWebApp < Angelo::Base
+    get '/up_and_running' do
+      'ok'
+    end
+  end
+
+  describe 'test Angelo::Base subclasses' do
+    define_app_by_class MyWebApp
+    it 'answers to up_and_running' do
+      get '/up_and_running'
+      assert_equal(last_response.body, 'ok')
+    end
+  end
+
   describe 'dsl configs' do
 
     describe 'addr' do

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -42,46 +42,7 @@ class CountDownLatch
 
 end
 
-module Cellper
-
-  @@stop = false
-  @@testers = {}
-
-  def define_action sym, &block
-    define_method sym, &block
-  end
-
-  def remove_action sym
-    remove_method sym
-  end
-
-  def unstop!
-    @@stop = false
-  end
-
-  def stop!
-    @@stop = true
-  end
-
-  def stop?
-    @@stop
-  end
-
-  def testers; @@testers; end
-
-end
-
-class Reactor
-  include Celluloid::IO
-  extend Cellper
-end
-
 $reactor = Reactor.new
-
-class ActorPool
-  include Celluloid
-  extend Cellper
-end
 
 $pool = ActorPool.pool size: CONCURRENCY
 


### PR DESCRIPTION
This addition was needed to test a web service class derived from Angelo::Base. See test/angelo_spec.rb, line 452.