### PR TITLE
Filters

### DIFF
--- a/lib/angelo/base.rb
+++ b/lib/angelo/base.rb
@@ -82,13 +82,6 @@ module Angelo
         !!@report_errors
       end
 
-      def compile! name, &block
-        define_method name, &block
-        method = instance_method name
-        remove_method name
-        method
-      end
-
       def routes
         @routes ||= Hash.new{|h,k| h[k] = RouteMap.new}
       end

--- a/lib/angelo/base.rb
+++ b/lib/angelo/base.rb
@@ -323,21 +323,17 @@ module Angelo
     end
 
     def filter which
-      fs = self.class.filters[which][:default].dup
-      self.class.filters[which].each do |pattern, f|
-        if ::Mustermann === pattern and pattern.match request.path
-          fs << [f, pattern]
-        end
-      end
-      fs.each do |f|
-        case f
-        when Proc
-          instance_eval(&f)
-        when Array
-          @pre_filter_params = params
-          @params = @pre_filter_params.merge f[1].params(request.path)
-          f[0].each {|filter| instance_eval(&filter)}
-          @params = @pre_filter_params
+      self.class.filters[which].each do |pattern, filters|
+        case pattern
+        when :default
+          filters.each {|filter| instance_eval &filter}
+        when ::Mustermann
+          if pattern.match request.path
+            @pre_filter_params = params
+            @params = @pre_filter_params.merge pattern.params(request.path)
+            filters.each {|filter| instance_eval &filter}
+            @params = @pre_filter_params
+          end
         end
       end
     end

--- a/lib/angelo/responder.rb
+++ b/lib/angelo/responder.rb
@@ -31,7 +31,7 @@ module Angelo
     attr_writer :base
 
     def initialize &block
-      @response_handler = Base.compile! :request_handler, &block
+      @response_handler = block
     end
 
     def reset!
@@ -44,7 +44,7 @@ module Angelo
     def handle_request
       if @response_handler
         @base.filter :before
-        @body = catch(:halt) { @response_handler.bind(@base).call || EMPTY_STRING }
+        @body = catch(:halt) { @base.instance_exec(&@response_handler) || EMPTY_STRING }
 
         # TODO any real reason not to run afters with SSE?
         case @body

--- a/lib/angelo/responder/eventsource.rb
+++ b/lib/angelo/responder/eventsource.rb
@@ -13,29 +13,30 @@ module Angelo
       end
 
       def handle_request
-        begin
-          if @response_handler
-            @base.filter :before
-            @body = catch(:halt) { @base.eventsource &@response_handler.bind(@base) }
-            if HALT_STRUCT === @body
-              raise RequestError.new 'unknown sse error' unless @body.body == :sse
-            end
-
-            # TODO any real reason not to run afters with SSE?
-            # @base.filter :after
-
-            respond
-          else
+        if !@response_handler
             raise NotImplementedError
-          end
-        rescue IOError => ioe
-          warn "#{ioe.class} - #{ioe.message}"
-        rescue RequestError => re
-          headers SSE_HEADER
-          handle_error re, re.type
-        rescue => e
-          handle_error e
         end
+        @base.filter :before
+        @body = catch(:halt) do
+          @base.eventsource do |socket|
+            @base.instance_exec(socket, &@response_handler)
+          end
+        end
+        if HALT_STRUCT === @body
+          raise RequestError.new 'unknown sse error' unless @body.body == :sse
+        end
+
+        # TODO any real reason not to run afters with SSE?
+        # @base.filter :after
+
+        respond
+      rescue IOError => ioe
+        warn "#{ioe.class} - #{ioe.message}"
+      rescue RequestError => re
+        headers SSE_HEADER
+        handle_error re, re.type
+      rescue => e
+        handle_error e
       end
 
       def respond

--- a/lib/angelo/responder/websocket.rb
+++ b/lib/angelo/responder/websocket.rb
@@ -22,10 +22,9 @@ module Angelo
         begin
           if @response_handler
             Angelo.log @connection, @request, @websocket, :switching_protocols
-            @bound_response_handler ||= @response_handler.bind @base
             @websocket.on_pong &Responder::Websocket.on_pong
             @base.filter :before
-            @bound_response_handler[@websocket]
+            @base.instance_exec(@websocket, &@response_handler)
             @base.filter :after
           else
             raise NotImplementedError


### PR DESCRIPTION
I was trying to figure out what compile! was good for.  It converts a block to an UnboundMethod that can be bound to an Angelo::Base instance and called.  But why bother.  It seems more ruby to keep it as a block and call it with instance_eval, or instance_exec if it needs arguments.

This PR is strictly a refactoring with three somewhat related commits.  Take them or leave them.
* Filters are just blocks that are instance_evalled.
* compile! is removed and everything else it was used for just stays as a block.
* The filter invocation code is cleaned up.

Sorry to be kind of hyperactive.  I've actually got any number of small tweaks to suggest that I've come across while going through the code.