### PR TITLE
Add ContentTypeHandlers

### DIFF
--- a/lib/angelo.rb
+++ b/lib/angelo.rb
@@ -33,9 +33,9 @@ module Angelo
   HTML_TYPE = 'text/html'
   JSON_TYPE = 'application/json'
   FORM_TYPE = 'application/x-www-form-urlencoded'
+  JS_TYPE = 'application/javascript'
+  XML_TYPE = 'application/xml'
   FILE_TYPE = 'application/octet-stream'
-  JS_TYPE =   'application/javascript'
-  XML_TYPE =  'application/xml'
 
   DEFAULT_ADDR = '127.0.0.1'
   DEFAULT_PORT = 4567
@@ -45,9 +45,10 @@ module Angelo
 
   DEFAULT_LOG_LEVEL = ::Logger::INFO
   DEFAULT_RESPONSE_LOG_LEVEL = :info
+  DEFAULT_CONTENT_TYPE = :html
+  
 
   DEFAULT_RESPONSE_HEADERS = {
-    CONTENT_TYPE_HEADER_KEY => HTML_TYPE
   }
 
   NOT_FOUND = 'Not Found'
@@ -130,6 +131,8 @@ end
 require 'angelo/version'
 require 'angelo/params_parser'
 require 'angelo/server'
+require 'angelo/content_type_handler'
+require 'angelo/content_type_handlers/json_handler'
 require 'angelo/responder'
 require 'angelo/responder/eventsource'
 require 'angelo/responder/websocket'

--- a/lib/angelo/base.rb
+++ b/lib/angelo/base.rb
@@ -59,6 +59,10 @@ module Angelo
     # in Angelo::Base subclasses and in the top level DSL.
 
     module DSL
+      def add_content_type(type, mime, handler=nil, &block)
+        ContentTypeHandler.new(type, mime, handler, &block)
+      end
+
       def addr a = nil
         @addr = a if a
         @addr
@@ -219,7 +223,7 @@ module Angelo
       end
 
     end
-
+    
     def initialize responder
       @responder = responder
       @klass = self.class
@@ -252,6 +256,18 @@ module Angelo
         end
       end
     end
+    
+    add_content_type :json, JSON_TYPE, JSONHandler
+    add_content_type :html, HTML_TYPE do |body|
+      case body
+      when String
+        body
+      else
+        raise 'html response requires a string'
+      end
+    end
+    add_content_type :xml, XML_TYPE
+    add_content_type :js, JS_TYPE
 
     task :handle_websocket do |ws|
       begin

--- a/lib/angelo/content_type_handler.rb
+++ b/lib/angelo/content_type_handler.rb
@@ -1,0 +1,65 @@
+module Angelo
+  class ContentTypeHandler
+    attr_accessor :type, :mime
+
+    class << self
+      def []=(type, handler)
+        @handlers ||= {}
+        @handlers[type] = handler
+      end
+
+      def [](type)
+        @handlers ||= {}
+        @handlers[type]
+      end
+      
+      def fetch_or_create(type_or_mime, handler_class, &block)
+        case type_or_mime
+        when String
+          ContentTypeHandler.new(nil,
+                                 type_or_mime,
+                                 handler_class,
+                                 &block)
+        when Symbol
+          ContentTypeHandler[type_or_mime] ||
+            raise(ArgumentError, "invalid content type: #{type}")
+        end
+      end
+    end
+
+    def initialize(type, mime, handler_class=nil, &block)
+      @type, @mime = type, mime
+      @handler = case
+                 when block_given?
+                   block
+                 when handler_class
+                   handler_class.new
+                 end
+      ContentTypeHandler[type] = self
+    end
+
+    def handle(body)
+      case @handler
+      when Proc
+        @handler.call(body)
+      when NilClass
+        body
+      else
+        @handler.handle(body)
+      end
+    end
+
+    def handle_error(error)
+      if @handler.respond_to?(:handle_error)
+        @handler.handle_error(error)
+      else
+        case error
+        when RequestError
+          handle(error.message.to_s)
+        else
+          handle(error.to_s)
+        end
+      end
+    end
+  end
+end

--- a/lib/angelo/content_type_handlers/json_handler.rb
+++ b/lib/angelo/content_type_handlers/json_handler.rb
@@ -1,0 +1,22 @@
+module Angelo
+  class JSONHandler
+    def handle(body)
+      case body
+      when String
+        JSON.parse body
+        body
+      when Hash
+        body.to_json
+      end
+    end
+
+    def handle_error(error)
+      case error
+      when String, Hash
+        handle({error: error})
+      else
+        handle({error: error.message})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow new content types to be declared with custom handling for response
creation and validation.

Closes #22 

---

I still need to add some tests for the content handler functionality. I figured I'd post this make sure you were okay with the design before I finished adding them.
