### PR TITLE
JSON array body support

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,21 @@ end
 HelloApp.run!
 ```
 
+### JSON HTTP API
+
+If you post JSON data with a JSON Content-Type, angelo will:
+
+* merge objects into the `params` SymHash
+* parse arrays and make them available via `request_body`
+
+N.B. `request_body` is functionally equivalent to `request.body.to_s` otherwise.
+
+If your `content_type` is set to `:json`, angelo will convert:
+
+* anything returned from a route block that `respond_to? :to_json`
+* `RequestError` message data
+* `halt` data
+
 ### Documentation
 
 **I'm bad at documentation and I feel bad.**

--- a/lib/angelo/base.rb
+++ b/lib/angelo/base.rb
@@ -12,6 +12,7 @@ module Angelo
     def_delegators :@klass, :public_dir, :report_errors?, :sse_event, :sse_message, :sses, :websockets
 
     attr_accessor :responder
+    attr_writer :request_body
 
     class << self
 
@@ -250,6 +251,10 @@ module Angelo
           hash[key] = value
         end
       end
+    end
+
+    def request_body
+      @request_body ||= request.body.to_s
     end
 
     task :handle_websocket do |ws|

--- a/test/angelo/params_spec.rb
+++ b/test/angelo/params_spec.rb
@@ -67,6 +67,20 @@ describe Angelo::ParamsParser do
     parser.parse_post_body.must_equal({})
   end
 
+  it "doesn't barf on JSON array POST bodies" do
+    parser.form_encoded = false
+    parser.json = true
+    parser.body = [123,234].to_json
+    ->{ parser.parse_post_body }.must_be_silent
+  end
+
+  it 'parses JSON array POST bodies' do
+    parser.form_encoded = false
+    parser.json = true
+    parser.body = [123,234].to_json
+    parser.parse_post_body.must_equal [123,234]
+  end
+
   it 'recursively symhashes JSON POST bodies params' do
     nested = {
       foo: {

--- a/test/angelo/params_spec.rb
+++ b/test/angelo/params_spec.rb
@@ -74,6 +74,13 @@ describe Angelo::ParamsParser do
     ->{ parser.parse_post_body }.must_be_silent
   end
 
+  it 'raises properly on malformed JSON' do
+    parser.form_encoded = false
+    parser.json = true
+    parser.body = "{F(34nfnlv,-935;:fho2fhlj}}}function(){console.log('hi');}"
+    ->{ parser.parse_post_body }.must_raise JSON::ParserError
+  end
+
   it 'parses JSON array POST bodies' do
     parser.form_encoded = false
     parser.json = true

--- a/test/angelo/websocket_spec.rb
+++ b/test/angelo/websocket_spec.rb
@@ -69,7 +69,7 @@ describe Angelo::Responder::Websocket do
     it 'responds on multiple websockets properly' do
       latch = CountDownLatch.new CONCURRENCY * 500
 
-      Reactor.testers[:wshs] = Array.new(CONCURRENCY).map do
+      Reactor.testers[:wshs] = Array.new CONCURRENCY do
         wsh = websocket_helper '/'
         wsh.on_message = ->(e) {
           assert_match /hi there \d/, e.data
@@ -286,7 +286,7 @@ describe Angelo::Responder::Websocket do
 
       latch = CountDownLatch.new CONCURRENCY
 
-      Reactor.testers[:hmc] = Array.new(CONCURRENCY).map do
+      Reactor.testers[:hmc] = Array.new CONCURRENCY do
         wsh = websocket_helper '/'
         wsh.on_message = ->(e) {
           wait_for_block[e]
@@ -298,7 +298,7 @@ describe Angelo::Responder::Websocket do
 
       one_latch = CountDownLatch.new CONCURRENCY
 
-      Reactor.testers[:hmc_one] = Array.new(CONCURRENCY).map do
+      Reactor.testers[:hmc_one] = Array.new CONCURRENCY do
         wsh = websocket_helper '/one'
         wsh.on_message = ->(e) {
           wait_for_block[e]
@@ -310,7 +310,7 @@ describe Angelo::Responder::Websocket do
 
       other_latch = CountDownLatch.new CONCURRENCY
 
-      Reactor.testers[:hmc_other] = Array.new(CONCURRENCY).map do
+      Reactor.testers[:hmc_other] = Array.new CONCURRENCY do
         wsh = websocket_helper '/other'
         wsh.on_message = ->(e) {
           wait_for_block[e]

--- a/test/angelo_spec.rb
+++ b/test/angelo_spec.rb
@@ -362,6 +362,11 @@ describe Angelo::Base do
       })
     end
 
+    it 'does not die on malformed JSON' do
+      post '/json_array?foo=bar', '{]sdfj2if08yth4j]j,:jsd;f; function()', {'Content-Type' => Angelo::JSON_TYPE}
+      last_response.status.must_equal 400
+    end
+
   end
 
   describe 'request_headers helper' do

--- a/test/angelo_spec.rb
+++ b/test/angelo_spec.rb
@@ -318,6 +318,11 @@ describe Angelo::Base do
         end
       end
 
+      post '/json_array' do
+        content_type :json
+        {params: params, body: request_body}
+      end
+
     end
 
     it 'parses formencoded body when content-type is formencoded' do
@@ -347,6 +352,14 @@ describe Angelo::Base do
         send m, '/json?foo'
         last_response_must_be_json('foo' => nil)
       end
+    end
+
+    it 'parses JSON array bodies but does not merge into params' do
+      post '/json_array?foo=bar', [123,234].to_json, {'Content-Type' => Angelo::JSON_TYPE}
+      last_response_must_be_json({
+        "params" => {"foo" => "bar"},
+        "body" => [123,234]
+      })
     end
 
   end


### PR DESCRIPTION
@gunnarmarten this should allow for what you want to do. at the very least, it should not crash the server anymore.

@tommay if you have a chance, i'd appreciate your thoughts on this as well.

what happens here is if you POST to /?foo=bar with a JSON array body, it will not get merged in to params, instead the parsed array will be available from the new `request_body` reader. in all other cases, `request_body` is functionally the same as `request.body.to_s`.

see #48 