### PR TITLE
Use tilt-preload gem to avoid non-thread safe autoload warnings.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'reel', github: 'celluloid/reel', branch: 'master'
 gem 'tilt', '~>2.0'
+gem 'tilt-preload'
 gem 'mime-types', '~>2.4'
 gem 'websocket-driver', '~>0.5'
 gem 'mustermann', '~>0.4'

--- a/angelo.gemspec
+++ b/angelo.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.1.0'
   gem.add_runtime_dependency 'reel', '~>0.5'
   gem.add_runtime_dependency 'tilt', '~>2.0'
+  gem.add_runtime_dependency 'tilt-preload'
   gem.add_runtime_dependency 'mustermann', '~>0.4'
   gem.add_runtime_dependency 'mime-types', '~>2.4'
 end

--- a/lib/angelo.rb
+++ b/lib/angelo.rb
@@ -1,6 +1,6 @@
 require 'reel'
 require 'json'
-require 'tilt'
+require 'tilt-preload'
 require 'mustermann'
 
 # require 'ruby-prof'


### PR DESCRIPTION
Bwa ha ha.  I haven't gotten any response on my tilt pull request to add preloading of tilt/* files instead of autoloading so I made a little tilt-preload gem to do it.  Here's a commit to make angelo use it; no more non-thread safe autoload warnings (as long as template gems are required before angelo).

This is an entirely serious little hack so if you like it go ahead and merge this PR.