### PR TITLE
Added default_headers DSL method

### DIFF
--- a/lib/angelo/base.rb
+++ b/lib/angelo/base.rb
@@ -95,6 +95,10 @@ module Angelo
       def content_type type
         Responder.content_type type
       end
+
+      def default_headers hs
+        Responder.default_headers = Responder.default_headers.merge hs
+      end
     end
 
     class << self

--- a/test/angelo_spec.rb
+++ b/test/angelo_spec.rb
@@ -583,6 +583,20 @@ describe Angelo::Base do
 
     end
 
+    describe 'default_headers' do
+
+      define_app do
+        default_headers "Access-Control-Allow-Origin" => "*"
+        get('/'){ 'hi' }
+      end
+
+      it 'adds a default headers' do
+        get '/'
+	last_response.headers['Access-Control-Allow-Origin'].must_equal "*"
+      end
+
+    end
+
   end
 
 end


### PR DESCRIPTION
This can be useful to add global response headers, for example CORS access control.