### PR TITLE
now dumps backtraces to configured logger

### DIFF
--- a/lib/angelo/responder.rb
+++ b/lib/angelo/responder.rb
@@ -73,10 +73,7 @@ module Angelo
       Angelo.log @method, @connection, @request, nil, type, err_msg.size
       @connection.respond type, headers, err_msg
       @connection.close
-      if report
-        error "#{_error.class} - #{_error.message}"
-        ::STDERR.puts _error.backtrace
-      end
+      error _error if report
     end
 
     def error_message _error


### PR DESCRIPTION
Is there any reason to explicitly dump backtraces to STDERR? If not, I suggest the following minor change.
This will help if the user has configured a special logger (e.g. logging via network to graylog or logstash) the backtraces will now be sent to this logger instead of landing in STDERR.

Ruby loggers normally detect if passed an exception, and dump the backtrace automatically. 