### PR TITLE
fix: responder not being recycled by GC for long live connection

### DIFF
--- a/lib/angelo/responder.rb
+++ b/lib/angelo/responder.rb
@@ -28,6 +28,7 @@ module Angelo
     end
 
     attr_accessor :connection, :mustermann, :request
+    attr_reader :on_close
     attr_writer :base
 
     def initialize method, &block
@@ -207,10 +208,6 @@ module Angelo
     def on_close= on_close
       raise ArgumentError.new unless Proc === on_close
       @on_close = on_close
-    end
-
-    def on_close
-      @on_close[] if @on_close
     end
 
   end

--- a/lib/angelo/server.rb
+++ b/lib/angelo/server.rb
@@ -22,15 +22,18 @@ module Angelo
 
     def on_connection connection
       # RubyProf.resume
-      responders = []
+      on_close_callbacks = []
 
       connection.each_request do |request|
         meth = request.websocket? ? :websocket : request.method.downcase.to_sym
         responder = dispatch! meth, connection, request
-        responders << responder if responder and responder.respond_to? :on_close
+
+        if responder && responder.respond_to?(:on_close) && responder.on_close
+          on_close_callbacks << responder.on_close
+        end
       end
 
-      responders.each &:on_close
+      on_close_callbacks.each &:call
       # RubyProf.pause
     end
 


### PR DESCRIPTION
Description:
after each request, server will push responder into an array.
if connection is alive for a long time, responders and objects they refer to won't be recycled by GC,
which may result in out of memory issue.

Solution:
push Proc instead of responder if on_close block defined.