### PR TITLE
fix sse on_close. invoke callback when socket is about to close.

### DIFF
--- a/lib/angelo.rb
+++ b/lib/angelo.rb
@@ -32,14 +32,16 @@ module Angelo
   ETAG_HEADER_KEY = 'ETag'
   IF_NONE_MATCH_HEADER_KEY = 'If-None-Match'
   LOCATION_HEADER_KEY = 'Location'
-  SSE_HEADER = { CONTENT_TYPE_HEADER_KEY => 'text/event-stream' }
 
   HTML_TYPE = 'text/html'
+  EVENT_STREAM_TYPE = 'text/event-stream'
   JSON_TYPE = 'application/json'
   FORM_TYPE = 'application/x-www-form-urlencoded'
   FILE_TYPE = 'application/octet-stream'
   JS_TYPE =   'application/javascript'
   XML_TYPE =  'application/xml'
+
+  SSE_HEADER = { CONTENT_TYPE_HEADER_KEY => EVENT_STREAM_TYPE }
 
   DEFAULT_ADDR = '127.0.0.1'
   DEFAULT_PORT = 4567

--- a/lib/angelo/base.rb
+++ b/lib/angelo/base.rb
@@ -419,7 +419,7 @@ module Angelo
     class EventSource
       extend Forwardable
 
-      def_delegators :@socket, :close, :closed?, :<<, :write, :peeraddr
+      def_delegators :@socket, :closed?, :<<, :write, :peeraddr
       attr_reader :responder, :socket
 
       def initialize responder
@@ -433,6 +433,12 @@ module Angelo
 
       def message data
         @socket.write Base.sse_message(data)
+      end
+
+      def close
+        return if @socket.closed?
+        @socket.close
+        @responder.on_close
       end
 
       def on_close &block

--- a/lib/angelo/responder.rb
+++ b/lib/angelo/responder.rb
@@ -129,6 +129,8 @@ module Angelo
       case headers[CONTENT_TYPE_HEADER_KEY]
       when JSON_TYPE
         type == :json
+      when EVENT_STREAM_TYPE
+        type == :event_stream
       else
         type == :html
       end

--- a/lib/angelo/server.rb
+++ b/lib/angelo/server.rb
@@ -22,15 +22,14 @@ module Angelo
 
     def on_connection connection
       # RubyProf.resume
-      responders = []
-
       connection.each_request do |request|
         meth = request.websocket? ? :websocket : request.method.downcase.to_sym
         responder = dispatch! meth, connection, request
-        responders << responder if responder and responder.respond_to? :on_close
-      end
 
-      responders.each &:on_close
+        if responder.is_a?(Angelo::Responder) && responder.respond_with?(:event_stream)
+          break # SSE keeps connection open, so we cannot handle more requests
+        end
+      end
       # RubyProf.pause
     end
 

--- a/test/angelo/eventsource_spec.rb
+++ b/test/angelo/eventsource_spec.rb
@@ -116,6 +116,15 @@ describe 'eventsource helper' do
       end
     end
 
+    get '/with_on_close' do
+      eventsource do |es|
+        es.on_close = ->{ sses(false).remove_socket es }
+        sses << es
+        es.message 'subscribed'
+        es.close
+      end
+    end
+
   end
 
   it 'sends messages' do
@@ -135,6 +144,13 @@ describe 'eventsource helper' do
       msg.must_equal "event: sse\ndata: headers\n\n"
     end
     last_response.headers['Foo'].must_equal 'bar'
+  end
+
+  it 'will run on_close callback when connection is closed' do
+    get_sse '/with_on_close' do |msg|
+      msg.must_equal "data: subscribed\n\n"
+    end
+    @server.sses(false).length.must_equal 0
   end
 
 end


### PR DESCRIPTION
Description:
after each request, server will push responder into an array.
if connection is alive for a long time, responders and objects they refer to won't be recycled by GC,
which may result in out of memory issue.
After deep diving Readme and source code, I guess on_close is a feature part of EventSource. websocket or normal http request is not supporting such feature (they don't have helper method from Angelo::Base to set the callback). 

Solution:
only execute on_close block for EventSource since there's no need for normal HTTP requests or websocket ones.
